### PR TITLE
Java SDK: better error propagation for actor not found errors

### DIFF
--- a/sdk-java/kar-actor-runtime/src/main/java/com/ibm/research/kar/actor/runtime/ActorRuntimeResource.java
+++ b/sdk-java/kar-actor-runtime/src/main/java/com/ibm/research/kar/actor/runtime/ActorRuntimeResource.java
@@ -119,12 +119,12 @@ public class ActorRuntimeResource {
 
 		ActorInstance actorObj = this.actorManager.getActor(type, id);
 		if (actorObj == null) {
-			return Response.status(Response.Status.NOT_FOUND).entity("Actor instance not found " + type + "actor" + id).build();
+			return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN).entity("Actor instance not found: " + type + "[" + id +"]").build();
 		}
 
 		MethodHandle actorMethod = this.actorManager.getActorMethod(type, path, args.size());
 		if (actorMethod == null) {
-			return Response.status(Response.Status.NOT_FOUND).entity("Cannot find method " + path + " with " + args.size() + " arguments").build();
+			return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN).entity("Method not found: " + type + "." + path + " with " + args.size() + " arguments").build();
 		}
 
 		// set the session

--- a/sdk-java/kar-rest-client/src/main/java/com/ibm/research/kar/Kar.java
+++ b/sdk-java/kar-rest-client/src/main/java/com/ibm/research/kar/Kar.java
@@ -121,6 +121,19 @@ public class Kar {
 		}
 	}
 
+	private static String responseToString(Response response) {
+		if (response.hasEntity()) {
+			MediaType type = response.getMediaType();
+			MediaType basicType = new MediaType(type.getType(), type.getSubtype());
+			if (basicType.equals(MediaType.APPLICATION_JSON_TYPE) || basicType.equals(KarRest.KAR_ACTOR_JSON_TYPE)) {
+				return response.readEntity(JsonValue.class).toString();
+			} else if (basicType.equals(MediaType.TEXT_PLAIN_TYPE)) {
+				return response.readEntity(String.class);
+			}
+		}
+		return null;
+	}
+
 	private static Reminder[] toReminderArray(Response response) {
 		try {
 			ArrayList<Reminder> res = new ArrayList<Reminder>();
@@ -491,7 +504,8 @@ public class Kar {
 				return callProcessResponse(response);
 			} catch (WebApplicationException e) {
 				if (e.getResponse() != null && e.getResponse().getStatus() == 404) {
-					throw new ActorMethodNotFoundException("Method not found: " + actor.getType() + "." + path, e);
+					String msg = responseToString(e.getResponse());
+					throw new ActorMethodNotFoundException(msg != null ? msg : "Not found: " + actor.getType() + "[" +actor.getId() + "]." + path, e);
 				} else if (e.getResponse() != null && e.getResponse().getStatus() == 408) {
 					throw new ActorMethodTimeoutException(
 							"Method timeout: " + actor.getType() + "[" + actor.getId() + "]." + path);
@@ -518,7 +532,8 @@ public class Kar {
 				return callProcessResponse(response);
 			} catch (WebApplicationException e) {
 				if (e.getResponse() != null && e.getResponse().getStatus() == 404) {
-					throw new ActorMethodNotFoundException("Method not found: " + actor.getType() + "." + path, e);
+					String msg = responseToString(e.getResponse());
+					throw new ActorMethodNotFoundException(msg != null ? msg : "Not found: " + actor.getType() + "[" +actor.getId() + "]." + path, e);
 				} else if (e.getResponse() != null && e.getResponse().getStatus() == 408) {
 					throw new ActorMethodTimeoutException(
 							"Method timeout: " + actor.getType() + "[" + actor.getId() + "]." + path);
@@ -544,7 +559,8 @@ public class Kar {
 				return callProcessResponse(response);
 			} catch (WebApplicationException e) {
 				if (e.getResponse() != null && e.getResponse().getStatus() == 404) {
-					throw new ActorMethodNotFoundException("Method not found: " + actor.getType() + "." + path, e);
+					String msg = responseToString(e.getResponse());
+					throw new ActorMethodNotFoundException(msg != null ? msg : "Not found: " + actor.getType() + "[" +actor.getId() + "]." + path, e);
 				} else if (e.getResponse() != null && e.getResponse().getStatus() == 408) {
 					throw new ActorMethodTimeoutException(
 							"Method timeout: " + actor.getType() + "[" + actor.getId() + "]." + path);


### PR DESCRIPTION
Improve propagation of detailed error message when a Java
actor instance, or a method on an actor instance, is not
found when it is invoked.