### PR TITLE
Java SDK: infinite default timeout

### DIFF
--- a/sdk-java/kar-rest-client/src/main/java/com/ibm/research/kar/KarConfig.java
+++ b/sdk-java/kar-rest-client/src/main/java/com/ibm/research/kar/KarConfig.java
@@ -26,7 +26,7 @@ public class KarConfig {
 	 */
 
 	// default read/write connection timeout
-	public static int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 600000;
+	public static int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 0;
 
 	// comma-delimited list of actor class names
 	public static String ACTOR_CLASS_STR;

--- a/sdk-java/kar-rest-client/src/main/java/com/ibm/research/kar/KarRest.java
+++ b/sdk-java/kar-rest-client/src/main/java/com/ibm/research/kar/KarRest.java
@@ -43,7 +43,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-@Timeout(600000)
+@Timeout(0)
 @Path("kar/v1")
 @RegisterProvider(JSONProvider.class)
 public interface KarRest extends AutoCloseable {


### PR DESCRIPTION
Change the default timeout to `0` (infinite) for all connections
from the Java SDK to the KAR sidecar. Timeouts will be configured
and enforced within the KAR application mesh, not at the language
SDK level.