### PR TITLE
Move all non-trivial runtime functionality to kar-runtime-core

### DIFF
--- a/sdk-java/kar-runtime-core/src/main/java/com/ibm/research/kar/runtime/ActorManager.java
+++ b/sdk-java/kar-runtime-core/src/main/java/com/ibm/research/kar/runtime/ActorManager.java
@@ -16,6 +16,8 @@
 
 package com.ibm.research.kar.runtime;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -25,16 +27,31 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonValue;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.ibm.research.kar.Kar;
 import com.ibm.research.kar.actor.ActorInstance;
 import com.ibm.research.kar.actor.annotations.Activate;
 import com.ibm.research.kar.actor.annotations.Actor;
 import com.ibm.research.kar.actor.annotations.Deactivate;
 import com.ibm.research.kar.actor.annotations.Remote;
 
+/**
+ * The ActorManager is responsible for creating and removing the in-memory instances
+ * of KAR Actors and for invoking methods on them as requested by the applicaiton.
+ */
 public class ActorManager {
 
 	private final static String LOG_PREFIX = "ActorManager.";
 	private final static Logger logger = Logger.getLogger(ActorManager.class.getName());
+	private final static JsonBuilderFactory factory = Json.createBuilderFactory(Map.of());
 
 	// This map is read only once it is initialized.
 	private static final HashMap<String, ActorType> actorTypes = new HashMap<>();
@@ -46,7 +63,7 @@ public class ActorManager {
 	 * that are needed to instantiate Actor instances and invoke Actor methods.
 	 *
 	 * @param classList the list of Java classes that are actors
-	 * @param nameList the list of KAR actor types used to refer to the classes
+	 * @param nameList  the list of KAR actor types used to refer to the classes
 	 */
 	public static void initialize(List<String> classList, List<String> nameList) {
 		MethodHandles.Lookup lookup = MethodHandles.lookup();
@@ -120,50 +137,166 @@ public class ActorManager {
 		logger.info(LOG_PREFIX + "initialize: actor map initialized with " + actorTypes.size() + " entries");
 	}
 
-	public static ActorInstance getActor(String type, String id) {
-		return actorInstances.get(actorInstanceKey(type, id));
-	}
 
-	public static ActorInstance createActor(String type, String id) {
-		ActorType actorType = actorTypes.get(type);
-		if (actorType == null) {
-			return null;
-		}
-
-		Class<ActorInstance> actorClass = actorType.getActorClass();
-		try {
-			ActorInstance actorObj = actorClass.getConstructor().newInstance();
-			actorObj.setType(type);
-			actorObj.setId(id);
-			actorInstances.put(actorInstanceKey(type, id), actorObj);
-			return actorObj;
-		} catch (Throwable t) {
-			logger.severe(LOG_PREFIX + "createActor: " + t.toString());
-			return null;
-		}
-	}
-
-	public static boolean deleteActor(String type, String id) {
-		return actorInstances.remove(actorInstanceKey(type, id)) != null;
-	}
-
+	/**
+	 * Is the given type a known ActorType?
+	 * @param type the type to look for
+	 * @return <code>true</code> if type is a known actor type and <code>false</code> otherwise.
+	 */
 	public static boolean hasActorType(String type) {
 		return actorTypes.containsKey(type);
 	}
 
-	public static MethodHandle getActorMethod(String type, String name, int numParams) {
+
+	/**
+	 * Activate an actor instance if it is not already in memory. If the specified
+	 * instance is in memory already, simply return success. If the specified
+	 * instance it not in memory already, allocate a language-level instance for it
+	 * and, if provided by the ActorType, invoke the optional activate method.
+	 *
+	 * @param type The type of the actor instance to be activated
+	 * @param id   The id of the actor instance to be activated
+	 * @return A Response indicating success (200, 201) or an error condition (400,
+	 *         404)
+	 */
+	public static Response activateInstanceIfNotPresent(String type, String id) {
+		if (actorInstances.get(actorInstanceKey(type, id)) != null) {
+			// Already exists; nothing to do.
+			return Response.status(Response.Status.OK).build();
+		}
+
+		// Find the ActorType
 		ActorType actorType = actorTypes.get(type);
-		return actorType != null ? actorType.getRemoteMethods().get(name + ":" + numParams) : null;
+		if (actorType == null) {
+			return Response.status(Response.Status.NOT_FOUND).entity("Not found: " + type + " actor " + id).build();
+		}
+
+		// Allocate an instance
+		Class<ActorInstance> actorClass = actorType.getActorClass();
+		ActorInstance actorObj;
+		try {
+			actorObj = actorClass.getConstructor().newInstance();
+			actorObj.setType(type);
+			actorObj.setId(id);
+			actorInstances.put(actorInstanceKey(type, id), actorObj);
+		} catch (Throwable t) {
+			logger.severe(LOG_PREFIX + "activateInstanceIfNotPresent: " + t.toString());
+			return Response.status(Response.Status.BAD_REQUEST).entity(t.toString()).build();
+		}
+
+		// Call the optional activate method
+		try {
+			MethodHandle activate = actorType.getActivateMethod();
+			if (activate != null) {
+				activate.invoke(actorObj);
+			}
+			return Response.status(Response.Status.CREATED).entity("Created " + type + " actor " + id).build();
+		} catch (Throwable t) {
+			return Response.status(Response.Status.BAD_REQUEST).entity(t.toString()).build();
+		}
 	}
 
-	public static MethodHandle getActorActivateMethod(String type) {
+
+	/**
+	 * Deactivate an actor instance. If the ActorType has a deactivate method, it
+	 * will be invoked on the instance. The actor instance will be removed from the
+	 * in-memory state of the runtime.
+	 *
+	 * @param type The type of the actor instance to be deactivated
+	 * @param id   The id of the actor instance to be deactivated
+	 * @return A Response indicating success (200) or an error condition (400, 404)
+	 */
+	public static Response deactivateInstanceIfPresent(String type, String id) {
+		ActorInstance actorObj = actorInstances.get(actorInstanceKey(type, id));
+		if (actorObj == null) {
+			return Response.status(Response.Status.NOT_FOUND).entity("Not found: " + type + " actor " + id).build();
+		}
+
+		// Call the optional deactivate method
 		ActorType actorType = actorTypes.get(type);
-		return actorType != null ? actorType.getActivateMethod() : null;
+		if (actorType != null && actorType.getDeactivateMethod() != null) {
+			try {
+				actorType.getDeactivateMethod().invoke(actorObj);
+			} catch (Throwable t) {
+				return Response.status(Response.Status.BAD_REQUEST).entity(t.toString()).build();
+			}
+		}
+
+		// Actually remove the instance
+		actorInstances.remove(actorInstanceKey(type, id));
+
+		return Response.status(Response.Status.OK).build();
 	}
 
-	public static MethodHandle getActorDeactivateMethod(String type) {
+
+	/**
+	 * Invoke an actor method
+	 *
+	 * @param type The type of the actor
+	 * @param id The id of the target instancr
+	 * @param sessionid The session in which the method is being invoked
+	 * @param path The method to invoke
+	 * @param args The arguments to the method
+	 * @return a Response containing the result of the method invocation
+	 */
+	public static Response invokeActorMethod(String type, String id, String sessionid, String path, JsonArray args) {
+
+		ActorInstance actorObj = actorInstances.get(actorInstanceKey(type, id));
+		if (actorObj == null) {
+			return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN).entity("Actor instance not found: " + type + "[" + id +"]").build();
+		}
+
 		ActorType actorType = actorTypes.get(type);
-		return actorType != null ? actorType.getDeactivateMethod() : null;
+		MethodHandle actorMethod = actorType != null ? actorType.getRemoteMethods().get(path + ":" + args.size()) : null;
+		if (actorMethod == null) {
+			return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN).entity("Method not found: " + type + "." + path + " with " + args.size() + " arguments").build();
+		}
+
+		// set the session
+		actorObj.setSession(sessionid);
+
+		// build arguments array for method handle invoke
+		Object[] actuals = new Object[args.size() + 1];
+		actuals[0] = actorObj;
+		for (int i = 0; i < args.size(); i++) {
+			actuals[i + 1] = args.get(i);
+		}
+
+		try {
+			Object result = actorMethod.invokeWithArguments(actuals);
+			if (result == null && actorMethod.type().returnType().equals(Void.TYPE)) {
+				return Response.status(Response.Status.NO_CONTENT).build();
+			} else {
+				JsonValue jv = result != null ? (JsonValue)result : JsonValue.NULL;
+				JsonObject ro = factory.createObjectBuilder().add("value", jv).build();
+				return Response.status(Response.Status.OK).type(Kar.KAR_ACTOR_JSON).entity(ro).build();
+			}
+		} catch (Throwable t) {
+			if (KarConfig.SHORTEN_ACTOR_STACKTRACES) {
+				// Elide all of the implementation details above us in the backtrace
+				StackTraceElement [] fullBackTrace = t.getStackTrace();
+				for (int i=0; i<fullBackTrace.length; i++) {
+					if (fullBackTrace[i].getClassName().equals(ActorManager.class.getName()) && fullBackTrace[i].getMethodName().equals("invokeActorMethod")) {
+						StackTraceElement[] reducedBackTrace = new StackTraceElement[i+1];
+						System.arraycopy(fullBackTrace, 0, reducedBackTrace, 0, i+1);
+						t.setStackTrace(reducedBackTrace);
+						break;
+					}
+				}
+			}
+			JsonObjectBuilder ro = factory.createObjectBuilder();
+			ro.add("error", true);
+			ro.add("message", t.toString());
+			StringWriter sw = new StringWriter();
+			PrintWriter pw = new PrintWriter(sw);
+			t.printStackTrace(pw);
+			String backtrace = sw.toString();
+			if (backtrace.length() > KarConfig.MAX_STACKTRACE_SIZE) {
+				backtrace = backtrace.substring(0, KarConfig.MAX_STACKTRACE_SIZE) + "\n...Backtrace truncated due to message length restrictions\n";
+			}
+			ro.add("stack", sw.toString());
+			return Response.status(Response.Status.OK).type(Kar.KAR_ACTOR_JSON).entity(ro.build()).build();
+		}
 	}
 
 	private static String actorInstanceKey(String type, String instance) {

--- a/sdk-java/kar-runtime-liberty/src/main/java/com/ibm/research/kar/liberty/ActorRuntimeApplication.java
+++ b/sdk-java/kar-runtime-liberty/src/main/java/com/ibm/research/kar/liberty/ActorRuntimeApplication.java
@@ -18,7 +18,6 @@ package com.ibm.research.kar.liberty;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
@@ -26,10 +25,7 @@ import javax.ws.rs.core.Application;
 @ApplicationPath("/kar/impl/v1/")
 public class ActorRuntimeApplication extends Application {
 
-  private static Logger logger = Logger.getLogger(ActorRuntimeApplication.class.getName());
-
   public Set<Class<?>> getClasses() {
-    logger.info("Running ActorRuntimeApplication getClasses()");
     Set<Class<?>> classes = new HashSet<Class<?>>();
     classes.add(JSONProvider.class);
     classes.add(ActorRuntimeResource.class);

--- a/sdk-java/kar-runtime-liberty/src/main/java/com/ibm/research/kar/liberty/ActorRuntimeResource.java
+++ b/sdk-java/kar-runtime-liberty/src/main/java/com/ibm/research/kar/liberty/ActorRuntimeResource.java
@@ -16,17 +16,7 @@
 
 package com.ibm.research.kar.liberty;
 
-import java.lang.invoke.MethodHandle;
-
-import java.io.StringWriter;
-import java.io.PrintWriter;
-
-import javax.inject.Inject;
-import javax.json.Json;
 import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
-import javax.json.JsonValue;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -40,9 +30,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import com.ibm.research.kar.Kar;
-import com.ibm.research.kar.actor.ActorInstance;
 import com.ibm.research.kar.runtime.ActorManager;
-import com.ibm.research.kar.runtime.KarConfig;
 
 @Path("actor")
 public class ActorRuntimeResource {
@@ -51,50 +39,13 @@ public class ActorRuntimeResource {
 	@Path("{type}/{id}")
 	@Produces(MediaType.TEXT_PLAIN)
 	public Response getActor(@PathParam("type") String type, @PathParam("id") String id) {
-		if (ActorManager.getActor(type, id) != null) {
-			// Already exists; nothing to do.
-			return Response.status(Response.Status.OK).build();
-		}
-
-		// Allocate a new actor instance
-		ActorInstance actorObj = ActorManager.createActor(type, id);
-		if (actorObj == null) {
-			return Response.status(Response.Status.NOT_FOUND).entity("Not found: " + type + " actor " + id).build();
-		}
-
-		// Call the optional activate method
-		try {
-			MethodHandle activate = ActorManager.getActorActivateMethod(type);
-			if (activate != null) {
-				activate.invoke(actorObj);
-			}
-			return Response.status(Response.Status.CREATED).entity("Created " + type + " actor " + id).build();
-		} catch (Throwable t) {
-			return Response.status(Response.Status.BAD_REQUEST).entity(t.toString()).build();
-		}
+		return ActorManager.activateInstanceIfNotPresent(type, id);
 	}
 
 	@DELETE
 	@Path("{type}/{id}")
 	public Response deleteActor(@PathParam("type") String type, @PathParam("id") String id) {
-		ActorInstance actorObj = ActorManager.getActor(type, id);
-		if (actorObj == null) {
-			return Response.status(Response.Status.NOT_FOUND).entity("Not found: " + type + " actor " + id).build();
-		}
-
-		// Call the optional deactivate method
-		MethodHandle deactivate = ActorManager.getActorDeactivateMethod(type);
-		if (deactivate != null) {
-			try {
-				deactivate.invoke(actorObj);
-			} catch (Throwable t) {
-				return Response.status(Response.Status.BAD_REQUEST).entity(t.toString()).build();
-			}
-		}
-
-		// Actually remove the instance
-		ActorManager.deleteActor(type, id);
-		return Response.status(Response.Status.OK).build();
+		return ActorManager.deactivateInstanceIfPresent(type, id);
 	}
 
 	@HEAD
@@ -110,61 +61,6 @@ public class ActorRuntimeResource {
 	@Produces(Kar.KAR_ACTOR_JSON)
 	public Response invokeActorMethod(@PathParam("type") String type, @PathParam("id") String id,
 			@PathParam("sessionid") String sessionid, @PathParam("path") String path, JsonArray args) {
-
-		ActorInstance actorObj = ActorManager.getActor(type, id);
-		if (actorObj == null) {
-			return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN).entity("Actor instance not found: " + type + "[" + id +"]").build();
-		}
-
-		MethodHandle actorMethod = ActorManager.getActorMethod(type, path, args.size());
-		if (actorMethod == null) {
-			return Response.status(Response.Status.NOT_FOUND).type(MediaType.TEXT_PLAIN).entity("Method not found: " + type + "." + path + " with " + args.size() + " arguments").build();
-		}
-
-		// set the session
-		actorObj.setSession(sessionid);
-
-		// build arguments array for method handle invoke
-		Object[] actuals = new Object[args.size() + 1];
-		actuals[0] = actorObj;
-		for (int i = 0; i < args.size(); i++) {
-			actuals[i + 1] = args.get(i);
-		}
-
-		try {
-			Object result = actorMethod.invokeWithArguments(actuals);
-			if (result == null && actorMethod.type().returnType().equals(Void.TYPE)) {
-				return Response.status(Response.Status.NO_CONTENT).build();
-			} else {
-				JsonValue jv = result != null ? (JsonValue)result : JsonValue.NULL;
-				JsonObject ro = Json.createObjectBuilder().add("value", jv).build();
-				return Response.status(Response.Status.OK).type(Kar.KAR_ACTOR_JSON).entity(ro).build();
-			}
-		} catch (Throwable t) {
-			if (KarConfig.SHORTEN_ACTOR_STACKTRACES) {
-				// Elide all of the implementation details above us in the backtrace
-				StackTraceElement [] fullBackTrace = t.getStackTrace();
-				for (int i=0; i<fullBackTrace.length; i++) {
-					if (fullBackTrace[i].getClassName().equals(ActorRuntimeResource.class.getName()) && fullBackTrace[i].getMethodName().equals("invokeActorMethod")) {
-						StackTraceElement[] reducedBackTrace = new StackTraceElement[i+1];
-						System.arraycopy(fullBackTrace, 0, reducedBackTrace, 0, i+1);
-						t.setStackTrace(reducedBackTrace);
-						break;
-					}
-				}
-			}
-			JsonObjectBuilder ro = Json.createObjectBuilder();
-			ro.add("error", true);
-			ro.add("message", t.toString());
-			StringWriter sw = new StringWriter();
-			PrintWriter pw = new PrintWriter(sw);
-			t.printStackTrace(pw);
-			String backtrace = sw.toString();
-			if (backtrace.length() > KarConfig.MAX_STACKTRACE_SIZE) {
-				backtrace = backtrace.substring(0, KarConfig.MAX_STACKTRACE_SIZE) + "\n...Backtrace truncated due to message length restrictions\n";
-			}
-			ro.add("stack", sw.toString());
-			return Response.status(Response.Status.OK).type(Kar.KAR_ACTOR_JSON).entity(ro.build()).build();
-		}
+		return ActorManager.invokeActorMethod(type, id, sessionid, path, args);
 	}
 }


### PR DESCRIPTION
Restructure code to move the implementation of the actor runtime
to kar-runtime-core.  Simplify and cleanup code in several ways
during the process of moving it.

Now all that is left in kar-runtime-liberty is the Open Liberty
specific code that defines the REST APIs and handles server
initialization and configuration.