### PR TITLE
Also allow controlling sidecar ports via envvar

### DIFF
--- a/core/internal/config/config.go
+++ b/core/internal/config/config.go
@@ -355,6 +355,22 @@ Available commands:
 		ActorTypes = strings.Split(actorTypes, ",")
 	}
 
+	if RuntimePort == 0 {
+		if ptmp := os.Getenv("KAR_RUNTIME_PORT"); ptmp != "" {
+			if RuntimePort, err = strconv.Atoi(ptmp); err != nil {
+				logger.Fatal("error parsing KAR_RUNTIME_PORT as an integer")
+			}
+		}
+	}
+
+	if AppPort == 8080 {
+		if ptmp := os.Getenv("KAR_APP_PORT"); ptmp != "" {
+			if AppPort, err = strconv.Atoi(ptmp); err != nil {
+				logger.Fatal("error parsing KAR_APP_PORT as an integer")
+			}
+		}
+	}
+
 	if !KafkaEnableTLS {
 		ktmp := os.Getenv("KAFKA_ENABLE_TLS")
 		if ktmp == "" {


### PR DESCRIPTION
If the values for RuntimePort and AppPort were not changed from
their default values on the kar cmd line, then look for an
environment override via KAR_RUNTIME_PORT and KAR_APP_PORT.
This simplifies configuration when deploying as a container.