### PR TITLE
JavaSDK: fix @Produces annotation on Service.tell* routes in OpenLiberty sidecar

### DIFF
--- a/sdk-java/kar-runtime-liberty/src/main/java/com/ibm/research/kar/liberty/KarSidecar.java
+++ b/sdk-java/kar-runtime-liberty/src/main/java/com/ibm/research/kar/liberty/KarSidecar.java
@@ -60,28 +60,24 @@ public interface KarSidecar {
 	@Path("service/{service}/call/{path}")
 	@ClientHeaderParam(name = "Pragma", value = "async")
 	@Retry(maxRetries = KarConfig.MAX_RETRY)
-	@Produces(MediaType.TEXT_PLAIN)
 	public Response tellDelete(@PathParam("service") String service, @PathParam("path") String path);
 
 	@PATCH
 	@Path("service/{service}/call/{path}")
 	@ClientHeaderParam(name = "Pragma", value = "async")
 	@Retry(maxRetries = KarConfig.MAX_RETRY)
-	@Produces(MediaType.TEXT_PLAIN)
 	public Response tellPatch(@PathParam("service") String service, @PathParam("path") String path, JsonValue params);
 
 	@POST
 	@Path("service/{service}/call/{path}")
 	@ClientHeaderParam(name = "Pragma", value = "async")
 	@Retry(maxRetries = KarConfig.MAX_RETRY)
-	@Produces(MediaType.TEXT_PLAIN)
 	public Response tellPost(@PathParam("service") String service, @PathParam("path") String path, JsonValue params);
 
 	@PUT
 	@Path("service/{service}/call/{path}")
 	@ClientHeaderParam(name = "Pragma", value = "async")
 	@Retry(maxRetries = KarConfig.MAX_RETRY)
-	@Produces(MediaType.TEXT_PLAIN)
 	public Response tellPut(@PathParam("service") String service, @PathParam("path") String path, JsonValue params);
 
 	// synchronous service invocation, returns invocation result


### PR DESCRIPTION
The "Accept" part of the header should be application/json, not
text/plain whether we are doing a tell or call because we pass the
header through to the target service.