### PR TITLE
Revert "log session.timeout.ms at info level (#297)"

### DIFF
--- a/core/pkg/rpc/dial.go
+++ b/core/pkg/rpc/dial.go
@@ -127,8 +127,6 @@ func configureConsumer(config *Config) *sarama.Config {
 	// we decide how to assign partitions to nodes
 	conf.Consumer.Group.Rebalance.Strategy = new(strategy)
 
-	logger.Info("kafka: session.timeout.ms = %v", conf.Consumer.Group.Session.Timeout.Milliseconds())
-
 	return conf
 }
 


### PR DESCRIPTION
Changed log analysis strategy; don't need this to be logged.