### PR TITLE
bug fix in actor locking -- overly forgiving reentrancy bypass

### DIFF
--- a/core/internal/runtime/commands.go
+++ b/core/internal/runtime/commands.go
@@ -318,6 +318,10 @@ func handlerActor(ctx context.Context, target rpc.Session, instance *rpc.Session
 		return nil, nil, err
 	}
 
+	if target.Flow != instance.ActiveFlow {
+		logger.Error("Reentrancy Violation: Flow mismatch between target %v and instance %v at entry", target, instance)
+	}
+
 	if msg["command"] == "delete" {
 		// delete SDK-level in-memory state
 		if instance.Activated {
@@ -422,6 +426,10 @@ func handlerActor(ctx context.Context, target rpc.Session, instance *rpc.Session
 			reply = nil
 			err = nil
 		}
+	}
+
+	if target.Flow != instance.ActiveFlow {
+		logger.Error("Reentrancy Violation: Flow mismatch between target %v and instance %v at exit", target, instance)
 	}
 
 	return dest, reply, err


### PR DESCRIPTION
The outermost call must clear activeFlow before scheduling the next
invocation on an actor instance to prevent a race condition where
a non-reentrant invocation using the same flow can conflict with
the next queued invocation that is being released.