### PR TITLE
Encode service result when invoked from actor tail call

### DIFF
--- a/examples/misc/actor-timeout-java/src/main/java/com/ibm/research/kar/example/timeout/Test.java
+++ b/examples/misc/actor-timeout-java/src/main/java/com/ibm/research/kar/example/timeout/Test.java
@@ -69,10 +69,14 @@ public class Test extends ActorSkeleton {
     }
   }
 
+  @Remote public Object doMath(JsonNumber v, JsonNumber toGo) {
+    return Kar.Actors.call(this, this, "incrTailCall", v, toGo);
+  }
+
   @Remote public Object incrTailCall(JsonNumber v, JsonNumber toGo) {
     System.out.println("incrTailCall: "+v+" "+toGo);
     if (toGo.intValue() == 0) {
-      return v;
+      return new Kar.Actors.TailCall("greeter", "increment", v);
     } else {
       return new Kar.Actors.TailCall(this, "incrTailCall", Json.createValue(v.intValue() + 1), Json.createValue(toGo.intValue() - 1));
     }

--- a/examples/service-hello-java/server/src/main/java/com/ibm/research/kar/example/hello/HelloServices.java
+++ b/examples/service-hello-java/server/src/main/java/com/ibm/research/kar/example/hello/HelloServices.java
@@ -16,6 +16,8 @@
 
 package com.ibm.research.kar.example.hello;
 
+import javax.json.Json;
+import javax.json.JsonNumber;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 import javax.json.spi.JsonProvider;
@@ -65,5 +67,19 @@ public class HelloServices {
     String msg = "Hello " + body;
     System.out.println(msg);
     return msg;
+  }
+
+  /**
+   * A simple increment service that consumes/produces JSON values
+   *
+   * @param body The request body
+   * @return A greeting message
+   */
+  @POST
+  @Path("increment")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public JsonValue increment(JsonNumber body) {
+    return Json.createValue(body.intValue() + 1);
   }
 }


### PR DESCRIPTION
If a service is invoked via an actor tail call and it returns
a normal (200) result with a non-empty result payload, kar must
wrap the result in the format expected by its caller
(application/kar+json).