### PR TITLE
bug fix in actor scheduling for recovery from a blocked self-call

### DIFF
--- a/examples/misc/fault-tolerance-actor/client.js
+++ b/examples/misc/fault-tolerance-actor/client.js
@@ -17,7 +17,7 @@
 const { actor } = require('kar-sdk')
 
 async function main () {
-  console.log(await actor.call(actor.proxy('A', 123), 'f', 42))
+  console.log(await actor.call(actor.proxy('A', 123), 'f', 42, true))
 }
 
 main()

--- a/examples/misc/fault-tolerance-actor/server.js
+++ b/examples/misc/fault-tolerance-actor/server.js
@@ -25,23 +25,22 @@ app.use(express.json({ strict: false }))
 // example actor
 
 class A {
-  async f (v) {
-    console.log('>', this.kar)
-    var result = await actor.call(this, actor.proxy('B', '123'), 'g', v)
-    console.log('<', this.kar)
+  async f (v, self) {
+    console.log('f >', this.kar)
+    const callee = self ? actor.proxy('A', this.kar.id) : actor.proxy('A', this.kar.id + this.kar.id)
+    const result = await actor.call(this, callee, 'g', v)
+    console.log('f <', this.kar)
     return result
   }
-}
 
-class B {
   async g (v) {
-    console.log('>', this.kar)
+    console.log('g >', this.kar)
     await new Promise(r => setTimeout(r, 15000))
-    console.log('<', this.kar)
+    console.log('g <', this.kar)
     return v + 1
   }
 }
 
-app.use(sys.actorRuntime({ A, B }))
+app.use(sys.actorRuntime({ A }))
 
 app.listen(process.env.KAR_APP_PORT, '127.0.0.1')


### PR DESCRIPTION
During recovery, when an message is identified as needing to be
blocked to wait for a child call to complete it is necessary to
eagerly set the activeFlow on the freshly created actor instance. This
recreates the locking state before recovery and allows re-entrant
calls to be properly identified as they are dequeued from kafka.

Also extend fault-tolerance-actor test case to include self-calls.