### PR TITLE
Disable actor collection for python tests

### DIFF
--- a/core/internal/config/config.go
+++ b/core/internal/config/config.go
@@ -234,7 +234,7 @@ Available commands:
 		description = "Run application component"
 		flag.StringVar(&ServiceName, "service", "", "The name of the service provided by this process")
 		flag.StringVar(&actorTypes, "actors", "", "The actor types provided by this process, as a comma separated list")
-		flag.DurationVar(&ActorCollectorInterval, "actor_collector_interval", 10*time.Second, "Actor collector interval")
+		flag.DurationVar(&ActorCollectorInterval, "actor_collector_interval", 10*time.Second, "Actor collector interval (0 disables collection)")
 		flag.DurationVar(&ActorReminderInterval, "actor_reminder_interval", 100*time.Millisecond, "Actor reminder processing interval")
 		flag.DurationVar(&ActorReminderAcceptableDelay, "actor_reminder_acceptable_delay", 3*time.Second, "Threshold at which reminders are logged as being late")
 		flag.IntVar(&AppPort, "app_port", 8080, "The port used by KAR to connect to the application")

--- a/core/internal/runtime/commands.go
+++ b/core/internal/runtime/commands.go
@@ -637,6 +637,10 @@ func deactivate(ctx context.Context, actor *rpc.SessionInstance) {
 
 // Collect periodically collect actors with no recent usage (but retains placement)
 func Collect(ctx context.Context) {
+	if config.ActorCollectorInterval == 0 {
+		logger.Info("Inactive actor collection disabled")
+		return
+	}
 	lock := make(chan struct{}, 1) // trylock
 	ticker := time.NewTicker(config.ActorCollectorInterval)
 	for {

--- a/examples/actors-python/launch.sh
+++ b/examples/actors-python/launch.sh
@@ -19,7 +19,7 @@
 set -e
 
 # Run the server:
-( kar run -app hello-actor -actors FamousActor -service actor-server-service python3 server/server.py ) &
+( kar run -actor_collector_interval 0s -app hello-actor -actors FamousActor -service actor-server-service python3 server/server.py ) &
 
 # Wait for server to start:
 sleep 2

--- a/examples/python-unit-tests/launch.sh
+++ b/examples/python-unit-tests/launch.sh
@@ -23,19 +23,19 @@ set -e
 
 
 # Test actor method calls:
-( kar run -h2c -app unit-test -app_port 8081 -actors TestActor,AnotherTestActor -service sdk-test python actor_server.py ) &
+( kar run -actor_collector_interval 0s -h2c -app unit-test -app_port 8081 -actors TestActor,AnotherTestActor -service sdk-test python actor_server.py ) &
 
 
 # Test state method calls:
-( kar run -h2c -app unit-test -app_port 8083 -actors TestActorState -service sdk-test-state python actor_state_server.py ) &
+( kar run -actor_collector_interval 0s -h2c -app unit-test -app_port 8083 -actors TestActorState -service sdk-test-state python actor_state_server.py ) &
 
 
 # Test state submap method calls:
-( kar run -h2c -app unit-test -app_port 8084 -actors TestActorSubState -service sdk-test-state-submap python actor_state_submap_server.py ) &
+( kar run -actor_collector_interval 0s -h2c -app unit-test -app_port 8084 -actors TestActorSubState -service sdk-test-state-submap python actor_state_submap_server.py ) &
 
 
 # Test eventing:
-( kar run -h2c -app unit-test -app_port 8085 -actors TestActorEvents -service sdk-test-events python actor_events_server.py ) &
+( kar run -actor_collector_interval 0s -h2c -app unit-test -app_port 8085 -actors TestActorEvents -service sdk-test-events python actor_events_server.py ) &
 
 
 # Run the client:


### PR DESCRIPTION
Python tests do not persist actor state via deactivate methods. Disable actor collection until the tests can be properly fixed.