### PR TITLE
Tolerate transient failures to connect to Redis or Kafka during startup

### DIFF
--- a/core/internal/runtime/runtime-main.go
+++ b/core/internal/runtime/runtime-main.go
@@ -165,7 +165,7 @@ func Main() {
 	}
 	redisConfig.RequestRetryLimit = config.RequestRetryLimit
 
-	if err = store.Dial(&redisConfig); err != nil {
+	if err = store.Dial(ctx, &redisConfig); err != nil {
 		logger.Fatal("failed to connect to Redis: %v", err)
 	}
 	defer store.Close()

--- a/core/pkg/checker/connect.go
+++ b/core/pkg/checker/connect.go
@@ -69,7 +69,7 @@ func (c *Connection) ConnectClient(appName string) {
 		Port:              redisPortInteger,
 	}
 
-	if err := store.Dial(sc); err != nil {
+	if err := store.Dial(c.ClientCtx, sc); err != nil {
 		log.Printf("failed to connect to Redis: %v", err)
 		os.Exit(1)
 	}

--- a/core/rpctest/server/server.go
+++ b/core/rpctest/server/server.go
@@ -64,7 +64,7 @@ func main() {
 		Port:              31379,
 	}
 
-	if err := store.Dial(sc); err != nil {
+	if err := store.Dial(ctx, sc); err != nil {
 		log.Printf("failed to connect to Reddis: %v", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixes #71.

During startup, wait up to 30 seconds to successfully connect to Redis and Kafka before exiting with an error.
