### PR TITLE
Revert "segregate primary and submap state in getall (#351)"

### DIFF
--- a/core/internal/runtime/routes-state.go
+++ b/core/internal/runtime/routes-state.go
@@ -75,13 +75,14 @@ func nestedEntryKeyPrefix(key string) string {
 // Check to see if the state of the actor instance indicated by `actorType` and `actorId`
 // contains an entry for `key`/`subkey`.
 //
-//	Consumes:
-//	- application/json
-//	Schemes: http
-//	Responses:
-//	  200: response200StateExistsResult
-//	  404: response404
-//	  500: response500
+//     Consumes:
+//     - application/json
+//     Schemes: http
+//     Responses:
+//       200: response200StateExistsResult
+//       404: response404
+//       500: response500
+//
 func routeImplContainsKey(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var mangledEntryKey string
 	if subkey := ps.ByName("subkey"); subkey != "" {
@@ -133,15 +134,16 @@ func routeImplContainsKey(w http.ResponseWriter, r *http.Request, ps httprouter.
 // The operation will not return until the state has been updated.
 // The result of the operation is `1` if a new entry was created and `0` if an existing entry was updated.
 //
-//	Consumes:
-//	- application/json
-//	Produces:
-//	- text/plain
-//	Schemes: http
-//	Responses:
-//	  201: response201
-//	  204: response204
-//	  500: response500
+//     Consumes:
+//     - application/json
+//     Produces:
+//     - text/plain
+//     Schemes: http
+//     Responses:
+//       201: response201
+//       204: response204
+//       500: response500
+//
 func routeImplSet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var mangledEntryKey string
 	if subkey := ps.ByName("subkey"); subkey != "" {
@@ -198,13 +200,14 @@ func routeImplSet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 // unless the boolean query parameter `nilOnAbsent` is set to `true`,
 // in which case a `200` reponse with a `nil` response body will be returned.
 //
-//	Produces:
-//	- application/json
-//	Schemes: http
-//	Responses:
-//	  200: response200StateGetResult
-//	  404: response404
-//	  500: response500
+//     Produces:
+//     - application/json
+//     Schemes: http
+//     Responses:
+//       200: response200StateGetResult
+//       404: response404
+//       500: response500
+//
 func routeImplGet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var mangledEntryKey string
 	if subkey := ps.ByName("subkey"); subkey != "" {
@@ -247,15 +250,16 @@ func routeImplGet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 // <li>size: return the number of entries the key actor map</li>
 // </ul>
 //
-//	Consumes:
-//	- application/json
-//	Produces:
-//	- application/json
-//	Schemes: http
-//	Responses:
-//	  200: response200StateSubmapOps
-//	  404: response404
-//	  500: response500
+//     Consumes:
+//     - application/json
+//     Produces:
+//     - application/json
+//     Schemes: http
+//     Responses:
+//       200: response200StateSubmapOps
+//       404: response404
+//       500: response500
+//
 func routeImplSubmapOps(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var op submapOp
 	if err := json.Unmarshal([]byte(ReadAll(r)), &op); err != nil {
@@ -399,12 +403,13 @@ func subMapScan(stateKey string, mapName string, op func(key string, value strin
 // The result of the operation is `1` if an entry was actually removed and
 // `0` if there was no entry for `key`.
 //
-//	Schemes: http
-//	Produces:
-//	- text/plain
-//	Responses:
-//	  200: response200StateDeleteResult
-//	  500: response500
+//     Schemes: http
+//     Produces:
+//     - text/plain
+//     Responses:
+//       200: response200StateDeleteResult
+//       500: response500
+//
 func routeImplDel(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var mangledEntryKey string
 	if subkey := ps.ByName("subkey"); subkey != "" {
@@ -428,12 +433,13 @@ func routeImplDel(w http.ResponseWriter, r *http.Request, ps httprouter.Params) 
 // The state of the actor instance indicated by `actorType` and `actorId`
 // will be returned as the response body.
 //
-//	Produces:
-//	- application/json
-//	Schemes: http
-//	Responses:
-//	  200: response200StateGetAllResult
-//	  500: response500
+//     Produces:
+//     - application/json
+//     Schemes: http
+//     Responses:
+//       200: response200StateGetAllResult
+//       500: response500
+//
 func routeImplGetAll(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	state, err := actorGetAllState(ps.ByName("type"), ps.ByName("id"))
 	if err != nil {
@@ -453,7 +459,6 @@ func actorGetAllState(actorType string, actorID string) (map[string]interface{},
 	// reply has type map[string]string
 	// we unmarshal the values then marshal the map
 	m := map[string]interface{}{}
-	submaps := map[string]map[string]interface{}{}
 	for i, s := range reply {
 		var v interface{}
 		json.Unmarshal([]byte(s), &v)
@@ -463,14 +468,11 @@ func actorGetAllState(actorType string, actorID string) (map[string]interface{},
 		if subkey == config.Separator {
 			m[key] = v
 		} else {
-			if submaps[key] == nil {
-				submaps[key] = map[string]interface{}{}
+			if m[key] == nil {
+				m[key] = map[string]interface{}{}
 			}
-			submaps[key][subkey] = v
+			(m[key].(map[string]interface{}))[subkey] = v
 		}
-	}
-	if len(submaps) > 0 {
-		m["submaps"] = submaps
 	}
 	return m, nil
 }
@@ -488,15 +490,16 @@ func actorGetAllState(actorType string, actorID string) (map[string]interface{},
 // The result of the operation will contain the number of state elements
 // removed and updated.
 //
-//	Consumes:
-//	- application/json
-//	Produces:
-//	- application/json
-//	Schemes: http
-//	Responses:
-//	  200: response200StateUpdate
-//	  404: response404
-//	  500: response500
+//     Consumes:
+//     - application/json
+//     Produces:
+//     - application/json
+//     Schemes: http
+//     Responses:
+//       200: response200StateUpdate
+//       404: response404
+//       500: response500
+//
 func routeImplStateUpdate(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var op stateUpdateOp
 	var err error
@@ -578,11 +581,12 @@ func routeImplStateUpdate(w http.ResponseWriter, r *http.Request, ps httprouter.
 // The state of the actor instance indicated by `actorType` and `actorId`
 // will be deleted.
 //
-//	Schemes: http
-//	Responses:
-//	  200: response200StateDeleteResult
-//	  404: response404
-//	  500: response500
+//     Schemes: http
+//     Responses:
+//       200: response200StateDeleteResult
+//       404: response404
+//       500: response500
+//
 func routeImplDelAll(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	if reply, err := store.Del(ctx, stateKey(ps.ByName("type"), ps.ByName("id"))); err == store.ErrNil {
 		http.Error(w, "Not Found", http.StatusNotFound)


### PR DESCRIPTION
This reverts commit 8ab3bf3767549402b53848cf8e98da9a32fe2fbc.

The reefer application depends on the previous structure of actor state, where the primary and submap state was not strictly segregated.