### PR TITLE
Fix debugger and metrics for Kubernetes single-container mode

### DIFF
--- a/core/internal/config/config.go
+++ b/core/internal/config/config.go
@@ -88,7 +88,10 @@ var (
 	RuntimePort int
 
 	// SidecarMode is true when this process is running in a sidecar container in a Kubernetes Pod
-	SidecarMode bool
+	SidecarMode bool // currently not used, but set by the injector anyways
+
+	// KubernetesMode is true when this process is running in a container in a Kubernetes Pod
+	KubernetesMode bool
 
 	// KafkaConfig contains the configuration information to connect with Kafka
 	KafkaConfig rpc.Config
@@ -241,6 +244,7 @@ Available commands:
 		flag.IntVar(&AppPort, "app_port", 8080, "The port used by KAR to connect to the application")
 		flag.IntVar(&RuntimePort, "runtime_port", 0, "The port used by the application to connect to KAR")
 		flag.BoolVar(&SidecarMode, "sidecar_mode", false, "Running as a sidecar container in a Kubernetes Pod")
+		flag.BoolVar(&KubernetesMode, "kubernetes_mode", false, "Running inside a container in a Kubernetes Pod")
 		flag.BoolVar(&H2C, "h2c", false, "Use h2c to communicate with service")
 		flag.StringVar(&Hostname, "hostname", "localhost", "Hostname")
 		flag.DurationVar(&KafkaConfig.SessionBusyTimeout, "actor_busy_timeout", 2*time.Minute, "Time to wait on a busy actor before timing out (0 is infinite)")

--- a/core/internal/runtime/runtime-main.go
+++ b/core/internal/runtime/runtime-main.go
@@ -151,7 +151,7 @@ func Main() {
 	}()
 
 	var listenHost string
-	if config.SidecarMode {
+	if config.KubernetesMode {
 		listenHost = fmt.Sprintf(":%d", config.RuntimePort)
 	} else {
 		listenHost = fmt.Sprintf("127.0.0.1:%d", config.RuntimePort)

--- a/core/internal/sidecar/injection.go
+++ b/core/internal/sidecar/injection.go
@@ -233,7 +233,7 @@ func possiblyInjectSidecar(ar v1.AdmissionReview) *v1.AdmissionResponse {
 func processAnnotations(pod corev1.Pod) ([]string, []corev1.EnvVar, string, bool) {
 	annotations := pod.GetObjectMeta().GetAnnotations()
 	appName := annotations[appNameAnnotation]
-	extraArgs := []string{"-config_dir", karRTConfigMount}
+	extraArgs := []string{"-kubernetes_mode", "-config_dir", karRTConfigMount}
 	appEnv := []corev1.EnvVar{{Name: "KAR_APP", Value: appName}}
 
 	var sidecarContainer = defaultSidecarContainer


### PR DESCRIPTION
To support the metrics stack (and the debugger), we need the kar sidecar to listen on :runtimePort (not 127.0.0.1:runtimePort) when we know we are running on Kubernetes, even if we are running both kar and the application in a single container and thus the application could talk to kar using just localhost:3500.